### PR TITLE
Fix when loaded assests placed them below the CACHE tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,11 @@ class AppCache {
 
   getManifestBody() {
     return [
-      this.assets && this.assets.length ? `${this.assets.join('\n')}\n` : null,
-      this.cache && this.cache.length ? `CACHE:\n${this.cache.join('\n')}\n` : null,
-      this.network && this.network.length ? `NETWORK:\n${this.network.join('\n')}\n` : null,
-      this.fallback && this.fallback.length ? `FALLBACK:\n${this.fallback.join('\n')}\n` : null,
-      this.settings && this.settings.length ? `SETTINGS:\n${this.settings.join('\n')}\n` : null,
+      this.assets && this.assets.length ? `CACHE:\n${this.assets.join('\n')}` : null,
+      this.cache && this.cache.length ? `${this.cache.join('\n')}\n` : null,
+      this.network && this.network.length ? `\nNETWORK:\n${this.network.join('\n')}` : null,
+      this.fallback && this.fallback.length ? `\nFALLBACK:\n${this.fallback.join('\n')}` : null,
+      this.settings && this.settings.length ? `\nSETTINGS:\n${this.settings.join('\n')}` : null,
     ].filter(v => v && v.length).join('\n');
   }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -184,14 +184,14 @@ describe('AppCache', () => {
     it('includes added assets', () => {
       const appCache = new AppCache();
       appCache.addAsset('test.asset');
-      assert(appCache.getManifestBody() === 'test.asset\n');
+      assert(appCache.getManifestBody() === 'CACHE:\ntest.asset');
     });
 
     describe('CACHE section', () => {
 
       it('includes CACHE section items', () => {
         const appCache = new AppCache(cacheEntries);
-        assert(appCache.getManifestBody() === 'CACHE:\ncache.test\n');
+        assert(appCache.getManifestBody() === 'cache.test\n');
       });
 
       it('excludes empty CACHE section', () => {
@@ -205,7 +205,7 @@ describe('AppCache', () => {
 
       it('includes NETWORK section items', () => {
         const appCache = new AppCache(null, networkEntries);
-        assert(appCache.getManifestBody() === 'NETWORK:\nnetwork.test\n');
+        assert(appCache.getManifestBody() === '\nNETWORK:\nnetwork.test');
       });
 
       it('excludes empty NETWORK section', () => {
@@ -219,7 +219,7 @@ describe('AppCache', () => {
 
       it('includes FALLBACK section items', () => {
         const appCache = new AppCache(null, null, fallbackEnteries);
-        assert(appCache.getManifestBody() === 'FALLBACK:\nfallback.test\n');
+        assert(appCache.getManifestBody() === '\nFALLBACK:\nfallback.test');
       });
 
       it('excludes empty FALLBACK section', () => {
@@ -233,7 +233,7 @@ describe('AppCache', () => {
 
       it('includes SETTINGS section', () => {
         const appCache = new AppCache(null, null, null, settingsEntries);
-        assert(appCache.getManifestBody() === 'SETTINGS:\nprefer-online\n');
+        assert(appCache.getManifestBody() === '\nSETTINGS:\nprefer-online');
       });
 
       it('excludes empty SETTINGS section', () => {
@@ -272,7 +272,7 @@ describe('AppCache', () => {
     it('measures byte size', () => {
       const hash = createHash('md5').digest('hex');
       const appCache = new AppCache(cacheEntries, networkEntries, fallbackEnteries, settingsEntries, hash);
-      assert(appCache.size() === 142);
+      assert(appCache.size() === 135);
     });
 
   });


### PR DESCRIPTION
At least for me, the following was happening:

Previously it was being generated like this:

```
    CACHE MANIFEST
        
    # 8a214e75b87d45313fa7
    
    app-8a214e75b87d45313fa7.bundle.js
    appReact-8a214e75b87d45313fa7.bundle.js
    vendors-8a214e75b87d45313fa7.js
    vendors-style-8a214e75b87d45313fa7.css
    index.html
    
    CACHE:
    other.js
    
    NETWORK:
    *
```

Is now being generated like this:

```
    CACHE MANIFEST

    # 8a214e75b87d45313fa7
    
    CACHE:
    other.js
    app-8a214e75b87d45313fa7.bundle.js
    appReact-8a214e75b87d45313fa7.bundle.js
    vendors-8a214e75b87d45313fa7.js
    vendors-style-8a214e75b87d45313fa7.css
    index.html
    
    NETWORK:
    *
```